### PR TITLE
Warn if CSS rules cannot be read in some browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   exactly what caused test to fail. Method is kept for backward compatibility, 
   but users of a programmatic API now encouraged to use `saveDiffTo` method of
   test result (passed to reporter) instead.
+* Warn if coverage for CSS file cannot be calculated due to
+  same-origin policy (@SevInf)
 
 ## 0.9.8 - 2015-02-11
 

--- a/lib/browser/client-scripts/gemini.coverage.js
+++ b/lib/browser/client-scripts/gemini.coverage.js
@@ -8,12 +8,18 @@
             sheets = document.styleSheets;
         try {
             for (var i = 0; i < sheets.length; i++) {
-                var rules = sheets[i].cssRules || sheets[i].rules,
-                    ctx = {
+                var href = sheets[i].href,
+                    rules = getRules(sheets[i]);
+
+                if (rules.ignored) {
+                    coverage[href] = rules;
+                    continue;
+                }
+                var ctx = {
                         // media rule counter
                         // coverage for media rules is stored by its index within stylesheet
                         media: -1,
-                        href: sheets[i].href,
+                        href: href,
                         coverage: coverage
                     };
                 for (var r = 0; r < rules.length; r++) {
@@ -29,6 +35,20 @@
 
         return coverage;
     };
+
+    function getRules(styleSheet) {
+        try {
+            return styleSheet.cssRules || styleSheet.rules;
+        } catch (e) {
+            if (e.name === 'SecurityError') {
+                return {
+                    ignored: true,
+                    message: 'Unable to read stylesheet rules due to the same origin policy'
+                };
+            }
+            throw e;
+        }
+    }
 
     function coverageForRule(rule, area, ctx) {
         if (rule.cssRules || rule.styleSheet) {

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -5,6 +5,7 @@ var inherit = require('inherit'),
     fs = require('fs'),
     url = require('url'),
     q = require('q'),
+    chalk = require('chalk'),
     qfs = require('q-io/fs'),
     http = require('q-io/http'),
     css = require('css'),
@@ -27,12 +28,20 @@ module.exports = inherit({
     },
 
     processStats: function() {
-        var _this = this;
+        var _this = this,
+            warned = {};
         this.stats.forEach(function(stat) {
             Object.keys(stat).forEach(function(file) {
+                var fileStat = stat[file];
+                if (fileStat.ignored && !warned[file]) {
+                    console.warn(chalk.yellow('WARNING:'), chalk.blue(file), 'may have inaccurate coverage report');
+                    console.warn(fileStat.message);
+                    warned[file] = true;
+                    return;
+                }
                 var rules = _this.byfile[file] = _this.byfile[file] || {};
 
-                Object.keys(stat[file]).forEach(function(rule) {
+                Object.keys(fileStat).forEach(function(rule) {
                     if (!rules[rule]) {
                         rules[rule] = stat[file][rule];
                     }


### PR DESCRIPTION
Due to same-origin policy in Firefox, css rules cannot be read if
stylesheet is loaded from a different domain. This patch adds warning
in this case (instead of crashing).