### PR TITLE
Use document height instead of body height

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -134,7 +134,7 @@
         window.scrollTo(rect.left, rect.top);
 
         var viewportHeight = window.innerHeight || document.documentElement.clientHeight,
-            bodyHeight = new Rect(document.querySelector('body').getBoundingClientRect()).height,
+            documentHeight = document.documentElement.scrollHeight,
             coverage;
 
         if (opts.coverage) {
@@ -149,7 +149,7 @@
             captureArea: rect.serialize(),
             ignoreAreas: findIgnoreAreas(opts.ignoreSelectors),
             viewportHeight: Math.round(viewportHeight),
-            bodyHeight: Math.round(bodyHeight),
+            documentHeight: Math.round(documentHeight),
             coverage: coverage,
             canHaveCaret: isEditable(document.activeElement)
         };

--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -67,7 +67,7 @@ module.exports = inherit({
             captureArea = prepareData.captureArea,
             bottomBorder = captureArea.top + captureArea.height;
 
-        if (imageSize.height < prepareData.bodyHeight) {
+        if (imageSize.height < prepareData.documentHeight) {
             bottomBorder -= prepareData.viewportOffset.top;
         }
 
@@ -94,7 +94,7 @@ module.exports = inherit({
                 'Can not capture specified region of the page\n' +
                 'The size of a region is larger then image, captured by browser\n' +
                 'Check that elements:\n' +
-                ' - does not overflows the body element\n' +
+                ' - does not overflows the document\n' +
                 ' - does not overflows browser viewport\n ' +
                 'Alternatively, you can increase browser window size using\n' +
                 '"setWindowSize" or "windowSize" option in config file.'
@@ -110,7 +110,7 @@ function isOutsideOfImage(area, imageSize) {
 }
 
 function getToImageCoordsFunction(image, prepareData) {
-    if (image.getSize().height >= prepareData.bodyHeight) {
+    if (image.getSize().height >= prepareData.documentHeight) {
         return function toImageCoords(area) {
             return area;
         };

--- a/test/capture-session.test.js
+++ b/test/capture-session.test.js
@@ -71,7 +71,7 @@ describe('capture session', function() {
 
         function setupImage(ctx, height) {
             ctx.browser.prepareScreenshot.returns({
-                bodyHeight: 100,
+                documentHeight: 100,
                 captureArea: {
                     top: 80,
                     left: 30,
@@ -147,7 +147,7 @@ describe('capture session', function() {
             });
         });
 
-        it('should crop screenshoot basing on viewport if image is less then body', function() {
+        it('should crop screenshoot basing on viewport if image is less then document', function() {
             var image = setupImageLessThenBody(this);
             return this.session.capture(this.state).then(function() {
                 sinon.assert.calledWith(image.crop, {
@@ -159,7 +159,7 @@ describe('capture session', function() {
             });
         });
 
-        it('should clear ignored areas basing on viewport if image is less then body', function() {
+        it('should clear ignored areas basing on viewport if image is less then document', function() {
             var image = setupImageLessThenBody(this);
             return this.session.capture(this.state).then(function() {
                 sinon.assert.calledWith(image.clear, {
@@ -171,7 +171,7 @@ describe('capture session', function() {
             });
         });
 
-        it('should crop screenshoot basing on body if image is greater then body', function() {
+        it('should crop screenshoot basing on document if image is greater then document', function() {
             var image = setupImageGreaterThenBody(this);
 
             return this.session.capture(this.state).then(function() {
@@ -184,7 +184,7 @@ describe('capture session', function() {
             });
         });
 
-        it('should clear ignored areas basing on body if image is greater then body', function() {
+        it('should clear ignored areas basing on document if image is greater then document', function() {
             var image = setupImageGreaterThenBody(this);
 
             return this.session.capture(this.state).then(function() {
@@ -197,13 +197,13 @@ describe('capture session', function() {
             });
         });
 
-        it('should fail when crop area is not located within body area', function(done) {
+        it('should fail when crop area is not located within document area', function(done) {
             this.state.name = 'state';
             this.state.suite = {name: 'suite'};
             this.browser.id = 'bro';
 
             this.browser.prepareScreenshot.returns({
-                bodyHeight: 100,
+                documentHeight: 100,
                 viewportOffset: {
                     top: 50,
                     left: 0


### PR DESCRIPTION
In some cases total document size might be greater then body. This
leads to incorrect classification of the viewport screenshot as a body
screenoshot. Thus, in cases when document is larger than viewport
scrolling is not taken into account and capture area is cropped
incorrectly.