### PR TITLE
Add suite path property to the report

### DIFF
--- a/lib/errors/no-ref-image-error.js
+++ b/lib/errors/no-ref-image-error.js
@@ -10,12 +10,13 @@ var NoRefImageError = inherit(StateError, {
      * @param {StateResult} result
      */
     __constructor: function(refImagePath, result) {
-        this.message = 'Can not find reference image at ' + refImagePath + '\n' +
+        this.message = 'Can not find reference image at ' + refImagePath + '.\n' +
             'Run `gemini gather` command to capture all reference images.';
 
         this.suiteName = result.suiteName;
         this.suiteId = result.suiteId;
         this.stateName = result.stateName;
+        this.suitePath = result.suitePath;
         this.browserId = result.browserId;
     }
 });
@@ -28,5 +29,6 @@ module.exports = NoRefImageError;
  * @property {String} suiteName
  * @property {String} suiteId
  * @property {String} stateName
+ * @property {String} suitePath
  * @property {String} browserId
  */

--- a/lib/reporters/flat.js
+++ b/lib/reporters/flat.js
@@ -1,95 +1,65 @@
 'use strict';
-var chalk = require('chalk');
+var chalk = require('chalk'),
+    util = require('util');
 
-var CHECK = chalk.green('\u2713'),
-    XMARK = chalk.red('\u2718'),
-    EXCLAMATION = chalk.bold.yellow('!');
+var BASE_TEMPLATE = '%s %s ' + chalk.underline('%s') + ' ' + chalk.yellow('[%s]'),
+    SUCCESS_TEMPLATE = util.format(BASE_TEMPLATE, chalk.green('\u2713')),
+    FAIL_TEMPLATE    = util.format(BASE_TEMPLATE, chalk.red('\u2718')),
+    WARNING_TEMPLATE = util.format(BASE_TEMPLATE, chalk.bold.yellow('!'));
+
+function log(template, stateResult) {
+    console.log(template, stateResult.suitePath.join(' '), stateResult.stateName, stateResult.browserId);
+}
 
 module.exports = function(runner) {
-    var browserSuites, failed, passed, skipped;
+    var failed, passed, skipped;
 
-    function reportSuccess(data) {
-        report(CHECK, data.stateName, data.browserId);
-    }
-
-    function reportFail(data) {
-        report(XMARK, data.stateName, data.browserId);
-    }
-
-    function reportWarn(data) {
-        report(EXCLAMATION, data.stateName, data.browserId);
-    }
-
-    function report(mark, stateName, browserId) {
-        var fullSuiteName = browserSuites[browserId].join(' ');
-        console.log('%s %s ' + chalk.underline('%s') + ' ' + chalk.yellow('[%s]'),
-            mark,
-            fullSuiteName,
-            stateName,
-            browserId
-        );
-    }
-
-    runner.on('begin', function(data) {
+    runner.on('begin', function() {
         failed = passed = skipped = 0;
-        browserSuites = {};
-        data.browserIds.forEach(function(browserId) {
-            browserSuites[browserId] = [];
-        });
-    });
-
-    runner.on('beginSuite', function(data) {
-        browserSuites[data.browserId].push(data.suiteName);
-    });
-
-    runner.on('endSuite', function(data) {
-        browserSuites[data.browserId].pop();
     });
 
     //for test command
     runner.on('endTest', function(result) {
         if (result.equal) {
-            reportSuccess(result);
+            log(SUCCESS_TEMPLATE, result);
             passed++;
         } else {
-            reportFail(result);
+            log(FAIL_TEMPLATE, result);
             failed++;
         }
     });
 
     //for gather command
-    runner.on('capture', function(data) {
-        reportSuccess(data);
+    runner.on('capture', function(result) {
+        log(SUCCESS_TEMPLATE, result);
         passed++;
     });
 
-    runner.on('error', function(error) {
-        reportFail(error);
-
-        if (error.originalError) {
-            error = error.originalError;
-        }
-        console.error(error.stack || error.message);
-
+    runner.on('error', function(errorResult) {
+        log(FAIL_TEMPLATE, errorResult);
         failed++;
+
+        var e = errorResult.originalError || errorResult;
+        console.error(e.stack || e.message);
     });
 
     /**
-     * @param {NoRefImageError} error
+     * @param {NoRefImageError} errorResult
      */
-    runner.on('warning', function(error) {
-        reportWarn(error);
-        console.warn(error.message);
-
+    runner.on('warning', function(errorResult) {
+        log(WARNING_TEMPLATE, errorResult);
         skipped++;
+
+        console.warn(errorResult.message);
     });
 
     runner.on('end', function() {
         var total = failed + passed + skipped;
         console.log('Total: %s Passed: %s Failed: %s Skipped: %s',
-                    chalk.underline(total),
-                    chalk.green(passed),
-                    chalk.red(failed),
-                    chalk.cyan(skipped));
+            chalk.underline(total),
+            chalk.green(passed),
+            chalk.red(failed),
+            chalk.cyan(skipped)
+        );
     });
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -90,6 +90,7 @@ module.exports = inherit(EventEmitter, {
             eventData = {
                 browserId: browser.id,
                 suiteName: suite.name,
+                suitePath: suite.path,
                 suiteId: suite.id
             };
 
@@ -142,6 +143,7 @@ module.exports = inherit(EventEmitter, {
             eventData = {
                 browserId: session.browser.id,
                 suiteName: state.suite.name,
+                suitePath: state.suite.path,
                 suiteId: state.suite.id,
                 stateName: state.name
             };
@@ -181,6 +183,7 @@ module.exports = inherit(EventEmitter, {
                     e.suiteId = state.suite.id;
                     e.suiteName = state.suite.name;
                     e.stateName = state.name;
+                    e.suitePath = state.suite.path;
                     e.browserId = session.browserId;
 
                     _this._stats.add('errored');

--- a/lib/screen-shooter.js
+++ b/lib/screen-shooter.js
@@ -20,6 +20,7 @@ module.exports = inherit(Runner, {
                     suiteName: capture.suite.name,
                     suiteId: capture.suite.id,
                     stateName: capture.state.name,
+                    suitePath: capture.suite.path,
                     imagePath: savePath,
                     browserId: capture.browser.id
                 };

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -106,6 +106,7 @@ exports.create = function createSuite(name, parent) {
     var suite = Object.create(parent);
     definePrivate(suite);
     suite.name = name;
+    suite.path = (parent && parent.path)? parent.path.concat(name) : [name];
     parent.addChild(suite);
     return suite;
 };

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -45,6 +45,7 @@ module.exports = inherit(Runner, {
                             suiteName: capture.suite.name,
                             suiteId: capture.suite.id,
                             stateName: capture.state.name,
+                            suitePath: capture.suite.path,
                             browserId: capture.browser.id
                         }));
                 }
@@ -65,6 +66,7 @@ module.exports = inherit(Runner, {
                     suiteName: capture.suite.name,
                     suiteId: capture.suite.id,
                     stateName: capture.state.name,
+                    suitePath: capture.suite.path,
                     equal: isEqual,
                     referencePath: refPath,
                     currentPath: currentPath,

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -150,6 +150,7 @@ describe('runner', function() {
                 sinon.assert.calledWith(spy, {
                     browserId: 'browser',
                     suiteName: 'suite',
+                    suitePath: ['suite'],
                     suiteId: 0
                 });
             });
@@ -193,7 +194,8 @@ describe('runner', function() {
                     browserId: 'browser',
                     suiteName: 'suite',
                     suiteId: 0,
-                    stateName: 'state'
+                    stateName: 'state',
+                    suitePath: ['suite']
                 });
             });
         });
@@ -224,7 +226,8 @@ describe('runner', function() {
                     browserId: 'browser',
                     suiteName: 'suite',
                     suiteId: 0,
-                    stateName: 'state'
+                    stateName: 'state',
+                    suitePath: ['suite']
                 });
             });
         });
@@ -352,7 +355,8 @@ describe('runner', function() {
                     browserId: 'browser',
                     suiteName: 'suite',
                     suiteId: 0,
-                    stateName: 'state'
+                    stateName: 'state',
+                    suitePath: ['suite']
                 });
             });
         });
@@ -412,6 +416,7 @@ describe('runner', function() {
                 e.suiteName.must.be('suite');
                 e.stateName.must.be('state');
                 e.browserId.must.be('browser');
+                e.suitePath.must.be.eql(['suite']);
                 done();
             });
             this.runner.run(this.root).done();
@@ -424,6 +429,7 @@ describe('runner', function() {
                 sinon.assert.calledWith(spy, {
                     browserId: 'browser',
                     suiteName: 'suite',
+                    suitePath: ['suite'],
                     suiteId: 0
                 });
             });
@@ -440,6 +446,7 @@ describe('runner', function() {
                 spy.secondCall.args.must.eql([{
                     browserId: 'browser',
                     suiteName: 'child',
+                    suitePath: ['suite', 'child'],
                     suiteId: 1
                 }]);
             });


### PR DESCRIPTION
My goal is to to make possible run test suites in parallel. The first step is make reporters independent from test suites hierarchy.
In this request I added `suitePath` property and refactored the `flat reporter`.
Next I will pull requests about `html reporter`, `teamcity reporter` and `moving grep before running tests`.