### PR TITLE
correct export __gemini in global scope

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -5,6 +5,8 @@ var util = require('./util'),
     rect = require('./rect'),
     Rect = rect.Rect;
 
+global.__gemini = exports;
+
 // Terminology
 // - clientRect - the result of calling getBoundingClientRect of the element
 // - extRect - clientRect + outline + box shadow

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -136,8 +136,7 @@ module.exports = inherit({
     buildScripts: function() {
         var script = browserify({
                 entries: './gemini',
-                basedir: path.join(__dirname, 'client-scripts'),
-                standalone: '__gemini'
+                basedir: path.join(__dirname, 'client-scripts')
             });
 
         if (!this.config.coverage) {


### PR DESCRIPTION
Browserify builds client-side scripts with **sandalone** option. Browserify uses [umd](https://github.com/umdjs/umd) wrapper for prepairing sandalone build.

If application uses requirejs following condition (from generated umd wrapper) will not allow `__gemini` to be exported into `window`:
```javascript
...
} else if (typeof define === "function" && define.amd) {
        define([], f)
}...
```

So [prepareScreenshot](https://github.com/bem/gemini/blob/master/lib/browser/index.js#L277) goes into infinity loop because [_prepareScreenshotCommand](https://github.com/bem/gemini/blob/master/lib/browser/index.js#L297) is trying to find `__gemini` in global scope.

We can solve this problem by rejecting *sandalone* option and using explicit `__gemini` exporting instead.

# In Russian
Клиентские скрипты собираются browserify с опцией **sandalone**, для создания *sandalone* билда browserify использует [umd](https://github.com/umdjs/umd) обертку. На страницах, где используется requirejs, следущее условие, генерируемое umd, не позволяет `__gemini` попасть в `window`:
```javascript
...
} else if (typeof define === "function" && define.amd) {
        define([], f)
}...
```
Из-за того, что [_prepareScreenshotCommand](https://github.com/bem/gemini/blob/master/lib/browser/index.js#L297) ожидает `__gemini` в глобальном скоупе, она никогда не сможет его найти и функция [prepareScreenshot](https://github.com/bem/gemini/blob/master/lib/browser/index.js#L277) уходит в бесконечную рекурсию.

Отказ от *sandalone* билда и явное экспортирование `__gemini` решит эту проблему.